### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "nodejs"
+  run = ""
+  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # toydelight
 
 Toy problems
+
+[![Run on Repl.it](https://repl.it/badge/github/Davidzsy20/toydelight)](https://repl.it/github/Davidzsy20/toydelight)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).